### PR TITLE
fix interval float precision when evicting buffer

### DIFF
--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -1586,7 +1586,7 @@ shaka.media.StreamingEngine = class {
         'overflow=' + overflow);
 
     await this.playerInterface_.mediaSourceEngine.remove(mediaState.type,
-        startTime, startTime + overflow);
+        Number(startTime).toFixed(3), Number(startTime + overflow).toFixed(3));
 
     this.destroyer_.ensureNotDestroyed();
     shaka.log.v1(logPrefix, 'evicted ' + overflow + ' seconds');


### PR DESCRIPTION
On Tizen TV models 2020 the parameters of SourceBuffer.remove() function are truncated to the third decimal position, this can lead to an error in case the interval evicted from buffer is just one millisecond.
For example if
presentationTime=42.001
bufferBehind=30
startTime=12
then
bufferedBehind = presentationTime - startTime // 30.000999999999998
overflow = bufferedBehind - bufferBehind // 0.0009999999999976694
so remove is called with
(startTime, startTime + overflow) // 12, 12.000999999999998
in this case we would get error
TypeError: Failed to execute 'remove' on 'SourceBuffer': The end value provided (12) must be greater than the start value provided (12)

Fixing the float precision before calling remove prevents the issue.