### PR TITLE
fix min eviction overflow

### DIFF
--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -1567,7 +1567,7 @@ shaka.media.StreamingEngine = class {
     }
     const bufferedBehind = presentationTime - startTime;
 
-    const overflow = bufferedBehind - bufferBehind;
+    let overflow = bufferedBehind - bufferBehind;
     if (overflow <= 0) {
       shaka.log.v2(logPrefix,
           'buffer behind okay:',
@@ -1578,6 +1578,7 @@ shaka.media.StreamingEngine = class {
       return;
     }
 
+    overflow = Math.max(overflow, 0.002);
     shaka.log.v1(logPrefix,
         'buffer behind too large:',
         'presentationTime=' + presentationTime,
@@ -1586,8 +1587,7 @@ shaka.media.StreamingEngine = class {
         'overflow=' + overflow);
 
     await this.playerInterface_.mediaSourceEngine.remove(mediaState.type,
-        Number(Number(startTime).toFixed(3)),
-        Number(Number(startTime + overflow).toFixed(3)));
+        startTime, startTime + overflow);
 
     this.destroyer_.ensureNotDestroyed();
     shaka.log.v1(logPrefix, 'evicted ' + overflow + ' seconds');


### PR DESCRIPTION
On Tizen TV models 2020 for certain values buffer eviction intervals of one millisecond fail to be properly passed to SourceBuffer.remove() function, for example values 31 and 31.001 are fine, but 32 and 32.001 trigger error:
TypeError: Failed to execute 'remove' on 'SourceBuffer': The end value provided (32) must be greater than the start value provided (32)

This fix imposes a two milliseconds minimum for buffer eviction.