### PR TITLE
fix memory leak in timline segments

### DIFF
--- a/lib/dash/segment_template.js
+++ b/lib/dash/segment_template.js
@@ -465,16 +465,18 @@ shaka.dash.SegmentTemplate = class {
           info.unscaledPresentationTimeOffset;
       const repId = context.representation.id;
       const bandwidth = context.bandwidth || null;
+      const baseUris = context.representation.baseUris;
+      const mediaTemplate = info.mediaTemplate;
       const createUris =
           () => {
             goog.asserts.assert(
-                info.mediaTemplate,
+                mediaTemplate,
                 'There should be a media template with a timeline');
             const mediaUri = MpdUtils.fillUriTemplate(
-                info.mediaTemplate, repId,
+                mediaTemplate, repId,
                 segmentReplacement, bandwidth || null, timeReplacement);
             return ManifestParserUtils
-                .resolveUris(context.representation.baseUris, [mediaUri])
+                .resolveUris(baseUris, [mediaUri])
                 .map((g) => {
                   return g.toString();
                 });


### PR DESCRIPTION
Every time the player loads a new SegmentReference it creates a `createUris` function that references the variables `context` and `info`.  Context in turn references the parsed manifest xml, while info references the timeline array that contains start and end of every fragment of the stream.
For the live stream that hits the out of memory, these two variables together hold about 1MB of memory and there's a new segment manifest loaded every 8 seconds, since all SegmentReferences are stored til the stream is over, the player eventually uses up all the device memory.
Technically speaking this is not a memory leak because all this memory is properly garbage collected once the player is dismissed, but the fix allows the objects to be collected immediately keeping a lower memory footprint.