### PR TITLE
added error after too many drm session expirations

### DIFF
--- a/lib/media/drm_engine.js
+++ b/lib/media/drm_engine.js
@@ -1453,9 +1453,20 @@ shaka.media.DrmEngine = class {
       // If this is part of a remove(), we don't want to close the session until
       // the update is complete.  Otherwise, we will orphan the session.
       if (found && !found.updatePromise) {
-        shaka.log.debug('Session has expired', session.sessionId);
-        this.activeSessions_.delete(session);
-        session.close().catch(() => {});  // Silence uncaught rejection errors
+        this.licenseAttempts++;
+        if (this.licenseAttempts > 2) {
+          this.licenseAttempts = 0;
+          const shakaErr = new shaka.util.Error(
+              shaka.util.Error.Severity.CRITICAL,
+              shaka.util.Error.Category.DRM,
+              shaka.util.Error.Code.LICENSE_REQUEST_FAILED,
+              'DRM session expired, too many attempts');
+          this.onError_(shakaErr);
+        } else {
+          shaka.log.debug('Session has expired', session.sessionId);
+          this.activeSessions_.delete(session);
+          session.close().catch(() => {});  // Silence uncaught rejection errors
+        }
       }
     }
 
@@ -1601,6 +1612,7 @@ shaka.media.DrmEngine = class {
       this.sendLicenseRequest_(event);
     }
 
+    this.licenseAttempts = 0;
     this.initialRequestsSent_ = true;
     this.mediaKeyMessageEvents_ = [];
   }


### PR DESCRIPTION
Using castlabs drm sometimes the session expiration gets stuck to an old date and shaka keeps requesting a new license in vain.
With this fix after 2 attempts an error is raised so that the application can react accordingly